### PR TITLE
fix things

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,31 @@
-const remark = require('remark');
+const remark = require('remark')
 const htmlify = require('remark-html')
-const remarkEmbedder = require('@remark-embedder/core')
-const oembedTransformer = require('@remark-embedder/transformer-oembed')
+const {default: remarkEmbedder} = require('@remark-embedder/core')
+const {
+  default: oembedTransformer,
+} = require('@remark-embedder/transformer-oembed')
 
-async function go(){
-    const exampleMarkdown = `# My favorite YouTube video
-    
-    [This](https://www.youtube.com/watch?v=dQw4w9WgXcQ) is a great YouTube video.
-    
-    Watch it here:
-    
-    https://www.youtube.com/watch?v=dQw4w9WgXcQ
-    
-    Isn't it great!?`
+async function go() {
+  const exampleMarkdown = `
+# My favorite YouTube video
+
+[This](https://www.youtube.com/watch?v=dQw4w9WgXcQ) is a great YouTube video.
+
+Watch it here:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+Isn't it great!?
+`.trim()
 
   const htmlResult = await remark()
     .use(remarkEmbedder, {
       transformers: [oembedTransformer],
     })
     .use(htmlify)
-    .process(exampleMarkdown);
+    .process(exampleMarkdown)
 
-    console.log(htmlResult.toString())
+  console.log(htmlResult.toString())
 }
 
-go();
+go()


### PR DESCRIPTION
Indentation is significant in markdown: https://astexplorer.net/#/gist/4c60491e89eb4b3d704a2fbb4cf6a3f2/21bff4fb05a561a6bb2fdb961a5c245bc7d40568

It was interpreting your markdown as a `code` node.

Also, with commonjs, you need to use `default` (as documented).